### PR TITLE
feat: config option to prepend to PATH, PYTHONPATH

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @broccolirob

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 * @broccolirob
+* @Xenomega

--- a/package.json
+++ b/package.json
@@ -70,6 +70,16 @@
                         "description": "Path to solc compiler used for analysis ('solc' if blank)",
                         "default": ""
                     },
+                    "slither.pathPrepend": {
+                        "type": "string",
+                        "description": "Value to prepend to $PATH environment variable for shell",
+                        "default": ""
+                    },
+                    "slither.pythonPathPrepend": {
+                        "type": "string",
+                        "description": "Value to prepend to $PYTHONPATH environment variable",
+                        "default": ""
+                    },
                     "slither.hiddenDetectors": {
                         "type": "array",
                         "description": "List of detectors which are hidden in the explorer",

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,10 +15,14 @@ export const storageFiles = {
 export interface UserConfiguration {
     solcPath : string;
     hiddenDetectors : string[];
+    pathPrepend?: string;
+    pythonPathPrepend?: string;
 }
 const defaultConfiguration : UserConfiguration = {
     solcPath: "", // default solc path (if blank, no custom path)
-    hiddenDetectors: [] // "check" properties to ignore in analysis results
+    hiddenDetectors: [], // "check" properties to ignore in analysis results
+    pathPrepend: "",
+    pythonPathPrepend: "",
 }
 export let userConfiguration : UserConfiguration = Object.assign({}, defaultConfiguration);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,6 +26,7 @@ export async function activate(context: vscode.ExtensionContext) {
     Logger.log("\u2E3B Slither: Solidity static analysis framework by Trail of Bits \u2E3B");
     
     // Initialize slither
+    config.readConfiguration();
     await slither.initialize();
 
     // Initialize the detector filter tree

--- a/src/slither.ts
+++ b/src/slither.ts
@@ -380,7 +380,20 @@ async function exec_slither(args : string[] | string, logError : boolean = true,
     let error : any;
     let stderr;
     let cmd = util.promisify(child_process.exec);
-    let { stdout } = await cmd(`${config.slitherPath} ${args}`, { cwd : workingDirectory, maxBuffer: maxBufferSize}).catch((e: any) => error = e);
+    const pathPrepend = config.userConfiguration.pathPrepend?.concat(":") ?? "";
+    const pythonPathPrepend = config.userConfiguration.pythonPathPrepend?.concat(":") ?? "";
+    let { stdout } = await cmd(
+      `${config.slitherPath} ${args}`,
+      {
+        cwd: workingDirectory,
+        maxBuffer: maxBufferSize,
+        env: {
+          ...process.env,
+          PATH: pathPrepend.concat(process.env["PATH"] ?? ""),
+          PYTHONPATH: pythonPathPrepend.concat(process.env["PYTHONPATH"] ?? ""),
+        },
+      },
+    ).catch((e: any) => error = e);
     
     // If we caught an error, copy our data from it.
     if(error) {


### PR DESCRIPTION
Context: Some developers use a version manager for Python. VSCode does not load a user's .bashrc/.zshrc which tends to result in a lot of command not found errors.